### PR TITLE
Update to Debian 12 & Java 17 to support JLineup 4.9.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
-on: [push]
-
+on:
+  push:
+  workflow_dispatch:
 jobs:
   custom_test:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,26 @@
-# Container image that runs your code
-FROM debian:buster-slim
+# Use bookworm / debian 12
+FROM debian:bookworm-slim
 
-RUN mkdir -p /usr/share/man/man1
-RUN apt-get update \
-    && apt-get install -y wget \
-    && apt-get install -y jq \
-    && apt-get install -yf default-jre-headless firefox-esr libjpeg-progs \
-    && wget --no-verbose -O jlineup-cli.jar "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=de.otto&a=jlineup-cli&v=LATEST&e=jar" \
-    #&& wget --no-verbose -O /jlineup-cli.jar "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=de.otto&a=jlineup-cli&e=jar&v=LATEST" \
+# Update packages
+RUN apt-get update && apt-get -y upgrade
+RUN apt-get install -y wget jq
+
+# Download JLineup executable
+RUN wget --no-verbose -O jlineup-cli.jar "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=de.otto&a=jlineup-cli&v=LATEST&e=jar"
+#RUN wget --no-verbose -O /jlineup-cli.jar "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=de.otto&a=jlineup-cli&e=jar&v=LATEST"
+
+# Install Chrome & Firefox
+RUN apt-get install -yf firefox-esr libjpeg-progs \
     && wget -O chrome.deb --no-verbose https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
     #&& wget -O chrome.deb --no-verbose https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb \
     #&& wget -O chrome.deb --no-verbose https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb \
     && apt-get install -y ./chrome.deb \
     && rm ./chrome.deb
 
-# Copies your code file from your action repository to the filesystem path `/` of the container
-COPY entrypoint.sh /entrypoint.sh
+# Install jre to execute JLineup
+RUN mkdir -p /usr/share/man/man1
+RUN apt-get install -yf default-jre-headless
 
-# Code file to execute when the docker container starts up (`entrypoint.sh`)
+# Copy endpoint.sh to image
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
fixes #5 

This PR will update debian from buster to bookworm. Therefore [default-jre-headless is using java 17](https://packages.debian.org/de/bookworm/default-jre-headless). 

It also changes the order of the installation of packages. This is needed to fix a problem while configure ca-certificates-java.