### PR TITLE
Update to debian 13 (trixie)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use bookworm / debian 12
-FROM debian:bookworm-slim
+# Use trixie / debian 13
+FROM debian:trixie-slim
 
 # Update packages
 RUN apt-get update && apt-get -y upgrade


### PR DESCRIPTION
We want to update debian cause it's not possible to install latest stable chrome due to old dependencies.